### PR TITLE
Upgrade hubot-slack

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "hubot": ">= 2.6.0 < 3.0.0",
     "hubot-scripts": ">= 2.5.0 < 3.0.0",
-    "hubot-slack": "~2.2.0"
+    "hubot-slack": "~3.3.0"
   },
   "engines": {
     "node": ">= 0.8.x",


### PR DESCRIPTION
hubot appears as offline and doesn't respond to commands with hubot-slack 2.2.0. Upgrading solved the problem. I'm not a Node programmer so I wasn't able to find the root cause.
